### PR TITLE
Fix transferTime in WindowsDisks by using 1-%Idle (#653)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 3.10.0 (in progress)
 ================
 * [#647](https://github.com/oshi/oshi/pull/647): Fix Windows idle counter calculation. - [@dbwiddis](https://github.com/dbwiddis).
+* [#653](https://github.com/oshi/oshi/pull/653): Fix transferTime in WindowsDisks by using 1-%Idle - [@Space2Man](https://github.com/Space2Man).
 * Your contribution here.
 
 3.9.0 (10/7/2018)


### PR DESCRIPTION
Fixes #628